### PR TITLE
Implement `Filterable`, add `mapWithAccum`+`when`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,8 @@
   "dependencies": {
     "purescript-prelude": "^3.0.0",
     "purescript-eff": "^3.0.0",
-    "purescript-sets": "^3.0.0"
+    "purescript-sets": "^3.0.0",
+    "purescript-filterable": "^2.3.0"
   },
   "devDependencies": {
     "purescript-math": "^2.0.0",

--- a/src/FRP/Event/Time.purs
+++ b/src/FRP/Event/Time.purs
@@ -4,8 +4,10 @@ module FRP.Event.Time
   , withTime
   ) where
 
+import Prelude ((<$>), (-))
+import Data.Tuple (Tuple(..))
 import Data.Unit (Unit)
-import FRP.Event (Event)
+import FRP.Event (Event, sampleOn_)
 
 -- | Create an event which fires every specified number of milliseconds.
 foreign import interval :: Int -> Event Int
@@ -15,3 +17,22 @@ foreign import animationFrame :: Event Unit
 
 -- | Create an event which reports the current time in milliseconds since the epoch.
 foreign import withTime :: forall a. Event a -> Event { value :: a, time :: Int }
+
+-- | Similar to `sampleOn_`, except that the returned `Event` is a `Tuple` of
+-- | the sampled value _as well as_ the time since that value was pushed to the
+-- | stream (in milliseconds).
+withDelay :: forall a b. Event a -> Event b -> Event (Tuple Int a)
+withDelay e sampler = go <$> stream
+  where
+
+    -- The stream with "current" and "first" stamps.
+    stream :: Event { time :: Int
+                    , value :: { time :: Int
+                               , value :: a } }
+    stream = withTime (sampleOn_ (withTime e) sampler)
+
+    -- Calculate a duration!
+    go :: { time :: Int, value :: { time :: Int, value :: a } }
+       -> Tuple Int a
+    go { time: now, value: { time: start, value } } =
+      Tuple (now - start) value


### PR DESCRIPTION
This commit adds two new functions to the library: `mapWithAccum`, a function to help map over streams with respect to an accumulating value, and `when`, which allows you to filter streams by other streams.

As well as this, the Filterable class has been added to replace a couple of other utilities, such as `filter` and `mapMaybe`. I don't know whether you're ok with this behaviour, @paf31, and I'm happy to re-add those utilities to help with BC. However, I thought it would help generalise a few procedures!