### PR TITLE
Add the `Filterable` typeclass to Event

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,8 @@
   "dependencies": {
     "purescript-prelude": "^3.0.0",
     "purescript-eff": "^3.0.0",
-    "purescript-sets": "^3.0.0"
+    "purescript-sets": "^3.0.0",
+    "purescript-filterable": "^2.3.0"
   },
   "devDependencies": {
     "purescript-math": "^2.0.0",

--- a/src/FRP/Event.js
+++ b/src/FRP/Event.js
@@ -69,7 +69,7 @@ exports.fold = function (f) {
   };
 };
 
-exports.filter = function (p) {
+exports.filterImpl = function (p) {
   return function(e) {
     return function(sub) {
       e(function(a) {

--- a/src/FRP/Event.purs
+++ b/src/FRP/Event.purs
@@ -2,8 +2,6 @@ module FRP.Event
   ( Event
   , fold
   , never
-  , filter
-  , mapMaybe
   , count
   , folded
   , withLast
@@ -11,12 +9,16 @@ module FRP.Event
   , sampleOn_
   , subscribe
   , create
+  , module Data.Filterable
   ) where
 
 import Prelude
+
 import Control.Alternative (class Alt, class Alternative, class Plus)
 import Control.Apply (lift2)
 import Control.Monad.Eff (Eff)
+import Data.Either (fromLeft, fromRight, isLeft, isRight)
+import Data.Filterable (class Filterable, eitherBool, filterMap)
 import Data.Maybe (Maybe(..), fromJust, isJust)
 import Data.Monoid (class Monoid, mempty)
 import FRP (FRP)
@@ -45,6 +47,23 @@ foreign import never :: forall a. Event a
 
 instance functorEvent :: Functor Event where
   map = mapImpl
+
+instance filterableEvent :: Filterable Event where
+  filter = filterImpl
+
+  filterMap f = unsafePartial $ map fromJust
+                            <<< filterImpl isJust
+                            <<< map f
+
+  partition p xs = let xs' = map (eitherBool p) xs in
+    { no:  unsafePartial $ map fromLeft  $ filterImpl isLeft  $ xs'
+    , yes: unsafePartial $ map fromRight $ filterImpl isRight $ xs'
+    }
+
+  partitionMap f xs = let xs' = f <$> xs in
+    { left:  unsafePartial $ map fromLeft  $ filterImpl isLeft  $ xs'
+    , right: unsafePartial $ map fromRight $ filterImpl isRight $ xs'
+    }
 
 instance applyEvent :: Apply Event where
   apply = applyImpl
@@ -82,16 +101,12 @@ folded s = fold append s mempty
 
 -- | Compute differences between successive event values.
 withLast :: forall a. Event a -> Event { now :: a, last :: Maybe a }
-withLast e = mapMaybe id (fold step e Nothing) where
+withLast e = filterMap id (fold step e Nothing) where
   step a Nothing           = Just { now: a, last: Nothing }
   step a (Just { now: b }) = Just { now: a, last: Just b }
 
 -- | Create an `Event` which only fires when a predicate holds.
-foreign import filter :: forall a. (a -> Boolean) -> Event a -> Event a
-
--- | Filter out any `Nothing` events.
-mapMaybe :: forall a b. (a -> Maybe b) -> Event a -> Event b
-mapMaybe f = unsafePartial (map fromJust <<< filter isJust <<< map f)
+foreign import filterImpl :: forall a. (a -> Boolean) -> Event a -> Event a
 
 -- | Create an `Event` which samples the latest values from the first event
 -- | at the times when the second event fires.


### PR DESCRIPTION
Previously, the `Event` type came with `filter` and `mapMaybe`. However,
these both existed within `Filterable`, and the `partition` functions
could also be implemented.

This PR implements the Filterable interface, and re-exports the
Filterable module from FRP.Event.