### PR TITLE
Add `withDelay` function

### DIFF
--- a/src/FRP/Event/Time.purs
+++ b/src/FRP/Event/Time.purs
@@ -1,11 +1,14 @@
 module FRP.Event.Time
   ( interval
   , animationFrame
+  , withDelay
   , withTime
   ) where
 
-import Data.Unit (Unit)
-import FRP.Event (Event)
+import Prelude
+
+import Data.Tuple (Tuple(..))
+import FRP.Event (Event, sampleOn_)
 
 -- | Create an event which fires every specified number of milliseconds.
 foreign import interval :: Int -> Event Int
@@ -15,3 +18,18 @@ foreign import animationFrame :: Event Unit
 
 -- | Create an event which reports the current time in milliseconds since the epoch.
 foreign import withTime :: forall a. Event a -> Event { value :: a, time :: Int }
+
+-- | Similar to `sampleOn_`, except that the returned `Event` is a `Tuple` of
+-- | the sampled value _as well as_ the time since that value was pushed to the
+-- | stream (in milliseconds). This can be useful for calculating progression
+-- | through fixed-length animations, or for establishing an expiration time on
+-- | events within a stream.
+withDelay :: forall a b. Event a -> Event b -> Event (Tuple Int a)
+withDelay e = map go <<< withTime <<< sampleOn_ (withTime e)
+  where
+
+    -- Calculate a duration!
+    go :: { time :: Int, value :: { time :: Int, value :: a } }
+       -> Tuple Int a
+    go { time: now, value: { time: start, value } } =
+      Tuple (now - start) value


### PR DESCRIPTION
This commit adds the `withDelay` function to `FRP.Event.Time`. My
personal reason for using this was that, for every tick of the RAF
event, I wanted to progress a pre-scripted animation. So, if the
animation were to last for 1000ms, the `withDelay` stream let me check
the progress through the animation, and then eventually when it had
finished (i.e. to stop animating).

I know this is a "maybe", @paf31, so I'm quite happy to have this one closed. As @justinwoo said, this library might not be the best place for hundreds of Rx operators! 🙃 