### PR TITLE
Return the current time as a Number

### DIFF
--- a/src/FRP/Behavior/Time.purs
+++ b/src/FRP/Behavior/Time.purs
@@ -7,5 +7,5 @@ import FRP.Behavior (Behavior, behavior)
 import FRP.Event.Time (withTime)
 
 -- | Get the current time in milliseconds since the epoch.
-millisSinceEpoch :: Behavior Int
+millisSinceEpoch :: Behavior Number
 millisSinceEpoch = behavior \e -> map (\{ value, time: t } -> value t) (withTime e)

--- a/src/FRP/Event/Time.purs
+++ b/src/FRP/Event/Time.purs
@@ -14,4 +14,4 @@ foreign import interval :: Int -> Event Int
 foreign import animationFrame :: Event Unit
 
 -- | Create an event which reports the current time in milliseconds since the epoch.
-foreign import withTime :: forall a. Event a -> Event { value :: a, time :: Int }
+foreign import withTime :: forall a. Event a -> Event { value :: a, time :: Number }

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -39,7 +39,7 @@ scene { w, h } = pure background <> map renderCircles circles where
   renderCircles = foldMap renderCircle
 
   seconds :: Behavior Number
-  seconds = map ((_ / 1000.0) <<< toNumber) Time.millisSinceEpoch
+  seconds = map (_ / 1000.0) Time.millisSinceEpoch
 
   -- `swell` is an interactive function of time defined by a differential equation:
   --


### PR DESCRIPTION
The `withTime` event now returns `time` as a `Number`, rather than an
`Int`. This is probably sensible, as the current time since epoch in ms
is bigger than what we can store in a 32-bit int, so this gets truncated
as soon as it is used. This commit simply changes its representation to
a number, ensuring that it can remain as precise.