### PR TITLE
Add switcher

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,8 @@
   "dependencies": {
     "purescript-prelude": "^3.0.0",
     "purescript-eff": "^3.0.0",
-    "purescript-sets": "^3.0.0"
+    "purescript-sets": "^3.0.0",
+    "purescript-nullable": "^3.0.0"
   },
   "devDependencies": {
     "purescript-math": "^2.0.0",

--- a/generated-docs/FRP/Behavior.md
+++ b/generated-docs/FRP/Behavior.md
@@ -84,6 +84,14 @@ Create a `Behavior` which is updated when an `Event` fires, by providing
 an initial value and a function to combine the current value with a new event
 to create a new value.
 
+#### `switcher`
+
+``` purescript
+switcher :: forall a. Behavior a -> Event (Behavior a) -> Behavior a
+```
+
+Switch `Behavior`s based on an `Event`.
+
 #### `integral`
 
 ``` purescript
@@ -211,7 +219,7 @@ Compute a fixed point
 #### `animate`
 
 ``` purescript
-animate :: forall scene eff. ABehavior Event scene -> (scene -> Eff (frp :: FRP | eff) Unit) -> Eff (frp :: FRP | eff) Unit
+animate :: forall scene eff. ABehavior Event scene -> (scene -> Eff (frp :: FRP | eff) Unit) -> Eff (frp :: FRP | eff) (Eff (frp :: FRP | eff) Unit)
 ```
 
 Animate a `Behavior` by providing a rendering function.

--- a/generated-docs/FRP/Behavior/Keyboard.md
+++ b/generated-docs/FRP/Behavior/Keyboard.md
@@ -8,4 +8,12 @@ keys :: Behavior (Set Int)
 
 A `Behavior` which reports the keys which are currently pressed.
 
+#### `key`
+
+``` purescript
+key :: Int -> Behavior Boolean
+```
+
+A `Behavior` which reports whether a specific key is currently pressed.
+
 

--- a/generated-docs/FRP/Event.md
+++ b/generated-docs/FRP/Event.md
@@ -81,13 +81,13 @@ Subscribe to an `Event` by providing a callback.
 
 `subscribe` returns a canceller function.
 
-#### `create`
+#### `fixE`
 
 ``` purescript
-create :: forall eff a. Eff (frp :: FRP | eff) { event :: Event a, push :: a -> Eff (frp :: FRP | eff) Unit }
+fixE :: forall i o. (Event i -> { input :: Event i, output :: Event o }) -> Event o
 ```
 
-Create an event and a function which supplies a value to that event.
+Compute a fixed point
 
 
 ### Re-exported from FRP.Event.Class:

--- a/generated-docs/FRP/Event.md
+++ b/generated-docs/FRP/Event.md
@@ -62,13 +62,24 @@ filter :: forall a. (a -> Boolean) -> Event a -> Event a
 
 Create an `Event` which only fires when a predicate holds.
 
+#### `keepLatest`
+
+``` purescript
+keepLatest :: forall a. Event (Event a) -> Event a
+```
+
+Flatten a nested `Event`, reporting values only from the most recent
+inner `Event`.
+
 #### `subscribe`
 
 ``` purescript
-subscribe :: forall eff a r. Event a -> (a -> Eff (frp :: FRP | eff) r) -> Eff (frp :: FRP | eff) Unit
+subscribe :: forall eff a r. Event a -> (a -> Eff (frp :: FRP | eff) r) -> Eff (frp :: FRP | eff) (Eff (frp :: FRP | eff) Unit)
 ```
 
 Subscribe to an `Event` by providing a callback.
+
+`subscribe` returns a canceller function.
 
 #### `create`
 

--- a/generated-docs/FRP/Event/Keyboard.md
+++ b/generated-docs/FRP/Event/Keyboard.md
@@ -16,4 +16,12 @@ up :: Event Int
 
 Create an `Event` which fires when a key is released
 
+#### `withKeys`
+
+``` purescript
+withKeys :: forall a. Event a -> Event { value :: a, keys :: Array Int }
+```
+
+Create an event which also returns the current pressed keycodes.
+
 

--- a/generated-docs/FRP/Event/Mouse.md
+++ b/generated-docs/FRP/Event/Mouse.md
@@ -24,4 +24,20 @@ up :: Event Int
 
 Create an `Event` which fires when a mouse button is released
 
+#### `withPosition`
+
+``` purescript
+withPosition :: forall a. Event a -> Event { value :: a, pos :: Nullable { x :: Int, y :: Int } }
+```
+
+Create an event which also returns the current mouse position.
+
+#### `withButtons`
+
+``` purescript
+withButtons :: forall a. Event a -> Event { value :: a, buttons :: Array Int }
+```
+
+Create an event which also returns the current mouse buttons.
+
 

--- a/src/FRP/Behavior.purs
+++ b/src/FRP/Behavior.purs
@@ -7,6 +7,7 @@ module FRP.Behavior
   , sampleBy
   , sample_
   , unfold
+  , switcher
   , integral
   , integral'
   , derivative
@@ -30,7 +31,7 @@ import Data.Maybe (Maybe(..))
 import Data.Monoid (class Monoid, mempty)
 import Data.Tuple (Tuple(Tuple))
 import FRP (FRP)
-import FRP.Event (class IsEvent, Event, create, fold, sampleOn, subscribe, withLast)
+import FRP.Event (class IsEvent, Event, create, fold, keepLatest, sampleOn, subscribe, withLast)
 import FRP.Event.Time (animationFrame)
 
 -- | `ABehavior` is the more general type of `Behavior`, which is parameterized
@@ -88,6 +89,11 @@ sampleBy f b e = sample (map f b) (map applyFlipped e)
 -- | Sample a `Behavior` on some `Event`, discarding the event's values.
 sample_ :: forall event a b. IsEvent event => ABehavior event a -> event b -> event a
 sample_ = sampleBy const
+
+-- | Switch `Behavior`s based on an `Event`.
+switcher :: forall a. Behavior a -> Event (Behavior a) -> Behavior a
+switcher b0 e = behavior \s ->
+  keepLatest (pure (sample b0 s) `alt` map (\b -> sample b s) e)
 
 -- | Integrate with respect to some measure of time.
 -- |
@@ -181,7 +187,7 @@ fixB :: forall a. a -> (ABehavior Event a -> ABehavior Event a) -> ABehavior Eve
 fixB a f = behavior \s -> unsafePerformEff do
   { event, push } <- create
   let b = f (step a event)
-  subscribe (sample_ b s) push
+  _ <- subscribe (sample_ b s) push
   pure (sampleOn event s)
 
 -- | Solve a first order differential equation of the form
@@ -269,5 +275,5 @@ animate
   :: forall scene eff
    . ABehavior Event scene
   -> (scene -> Eff (frp :: FRP | eff) Unit)
-  -> Eff (frp :: FRP | eff) Unit
+  -> Eff (frp :: FRP | eff) (Eff (frp :: FRP | eff) Unit)
 animate scene render = subscribe (sample_ scene animationFrame) render

--- a/src/FRP/Behavior/Keyboard.purs
+++ b/src/FRP/Behavior/Keyboard.purs
@@ -1,14 +1,18 @@
 module FRP.Behavior.Keyboard
   ( keys
+  , key
   ) where
 
 import Prelude
 
-import Control.Alt ((<|>))
 import Data.Set as Set
-import FRP.Behavior (Behavior, unfold)
-import FRP.Event.Keyboard (up, down)
+import FRP.Behavior (Behavior, behavior)
+import FRP.Event.Keyboard (withKeys)
 
 -- | A `Behavior` which reports the keys which are currently pressed.
 keys :: Behavior (Set.Set Int)
-keys = unfold id (Set.insert <$> down <|> Set.delete <$> up) Set.empty
+keys = behavior \e -> map (\{ value, keys: ks } -> value (Set.fromFoldable ks)) (withKeys e)
+
+-- | A `Behavior` which reports whether a specific key is currently pressed.
+key :: Int -> Behavior Boolean
+key k = Set.member k <$> keys

--- a/src/FRP/Behavior/Mouse.purs
+++ b/src/FRP/Behavior/Mouse.purs
@@ -17,4 +17,4 @@ position = behavior \e -> map (\{ value, pos } -> value (toMaybe pos)) (withPosi
 
 -- | A `Behavior` which reports the mouse buttons which are currently pressed.
 buttons :: Behavior (Set.Set Int)
-buttons = behavior \e -> map (\{ value, buttons } -> value (Set.fromFoldable buttons)) (withButtons e)
+buttons = behavior \e -> map (\{ value, buttons: bs } -> value (Set.fromFoldable bs)) (withButtons e)

--- a/src/FRP/Behavior/Mouse.purs
+++ b/src/FRP/Behavior/Mouse.purs
@@ -5,16 +5,16 @@ module FRP.Behavior.Mouse
 
 import Prelude
 
-import Control.Alt ((<|>))
-import Data.Maybe (Maybe(..))
+import Data.Maybe (Maybe)
+import Data.Nullable (toMaybe)
 import Data.Set as Set
-import FRP.Behavior (Behavior, step, unfold)
-import FRP.Event.Mouse (move, up, down)
+import FRP.Behavior (Behavior, behavior)
+import FRP.Event.Mouse (withPosition, withButtons)
 
 -- | A `Behavior` which reports the current mouse position, if it is known.
 position :: Behavior (Maybe { x :: Int, y :: Int })
-position = step Nothing (map Just move)
+position = behavior \e -> map (\{ value, pos } -> value (toMaybe pos)) (withPosition e)
 
 -- | A `Behavior` which reports the mouse buttons which are currently pressed.
 buttons :: Behavior (Set.Set Int)
-buttons = unfold id (Set.insert <$> down <|> Set.delete <$> up) Set.empty
+buttons = behavior \e -> map (\{ value, buttons } -> value (Set.fromFoldable buttons)) (withButtons e)

--- a/src/FRP/Event.js
+++ b/src/FRP/Event.js
@@ -144,7 +144,7 @@ exports.keepLatest = function (e) {
   };
 };
 
-exports.create = function () {
+function subject() {
   var subs = [];
   return {
     event: function(sub) {
@@ -157,11 +157,24 @@ exports.create = function () {
       };
     },
     push: function(a) {
-      return function() {
-        for (var i = 0; i < subs.length; i++) {
-          subs[i](a);
-        }
-      };
+      for (var i = 0; i < subs.length; i++) {
+        subs[i](a);
+      }
     }
+  };
+};
+
+exports.fixE = function(f) {
+  var s = subject();
+  var io = f(s.event);
+
+  return function(sub) {
+    var cancel1 = io.input(s.push);
+    var cancel2 = io.output(sub);
+
+    return function() {
+      cancel1();
+      cancel2();
+    };
   };
 };

--- a/src/FRP/Event.purs
+++ b/src/FRP/Event.purs
@@ -1,7 +1,5 @@
 module FRP.Event
   ( Event
-  , never
-  , keepLatest
   , subscribe
   , module Class
   ) where
@@ -77,6 +75,7 @@ instance monoidEvent :: Monoid a => Monoid (Event a) where
 
 instance eventIsEvent :: Class.IsEvent Event where
   fold = fold
+  keepLatest = keepLatest
   sampleOn = sampleOn
   fix = fix
 

--- a/src/FRP/Event.purs
+++ b/src/FRP/Event.purs
@@ -4,7 +4,7 @@ module FRP.Event
   , filter
   , keepLatest
   , subscribe
-  , create
+  , fixE
   , module Class
   ) where
 
@@ -87,6 +87,9 @@ foreign import sampleOn :: forall a b. Event a -> Event (a -> b) -> Event b
 -- | inner `Event`.
 foreign import keepLatest :: forall a. Event (Event a) -> Event a
 
+-- | Compute a fixed point
+foreign import fixE :: forall i o. (Event i -> { input :: Event i, output :: Event o }) -> Event o
+
 -- | Subscribe to an `Event` by providing a callback.
 -- |
 -- | `subscribe` returns a canceller function.
@@ -95,11 +98,3 @@ foreign import subscribe
    . Event a
   -> (a -> Eff (frp :: FRP | eff) r)
   -> Eff (frp :: FRP | eff) (Eff (frp :: FRP | eff) Unit)
-
--- | Create an event and a function which supplies a value to that event.
-foreign import create
-  :: forall eff a
-   . Eff (frp :: FRP | eff)
-         { event :: Event a
-         , push :: a -> Eff (frp :: FRP | eff) Unit
-         }

--- a/src/FRP/Event.purs
+++ b/src/FRP/Event.purs
@@ -2,6 +2,7 @@ module FRP.Event
   ( Event
   , never
   , filter
+  , keepLatest
   , subscribe
   , create
   , module Class
@@ -82,12 +83,18 @@ foreign import filter :: forall a. (a -> Boolean) -> Event a -> Event a
 -- | at the times when the second event fires.
 foreign import sampleOn :: forall a b. Event a -> Event (a -> b) -> Event b
 
+-- | Flatten a nested `Event`, reporting values only from the most recent
+-- | inner `Event`.
+foreign import keepLatest :: forall a. Event (Event a) -> Event a
+
 -- | Subscribe to an `Event` by providing a callback.
+-- |
+-- | `subscribe` returns a canceller function.
 foreign import subscribe
   :: forall eff a r
    . Event a
   -> (a -> Eff (frp :: FRP | eff) r)
-  -> Eff (frp :: FRP | eff) Unit
+  -> Eff (frp :: FRP | eff) (Eff (frp :: FRP | eff) Unit)
 
 -- | Create an event and a function which supplies a value to that event.
 foreign import create

--- a/src/FRP/Event/Class.purs
+++ b/src/FRP/Event/Class.purs
@@ -7,6 +7,7 @@ module FRP.Event.Class
   , withLast
   , sampleOn
   , sampleOn_
+  , keepLatest
   , fix
   , module Data.Filterable
   ) where
@@ -24,11 +25,14 @@ import Data.Tuple (Tuple(..), snd)
 -- |
 -- | - `fold`: combines incoming values using the specified function,
 -- | starting with the specific initial value.
+-- | - `keepLatest` flattens a nested event, reporting values only from the
+-- | most recent inner event.
 -- | - `sampleOn`: samples an event at the times when a second event fires.
 -- | - `fix`: compute a fixed point, by feeding output events back in as
 -- | inputs.
 class (Alternative event, Filterable event) <= IsEvent event where
   fold :: forall a b. (a -> b -> b) -> event a -> b -> event b
+  keepLatest :: forall a. event (event a) -> event a
   sampleOn :: forall a b. event a -> event (a -> b) -> event b
   fix :: forall i o. (event i -> { input :: event i, output :: event o }) -> event o
 

--- a/src/FRP/Event/Keyboard.js
+++ b/src/FRP/Event/Keyboard.js
@@ -1,5 +1,24 @@
 "use strict";
 
+var currentKeys = [];
+addEventListener("keydown", function(e) {
+  currentKeys.push(e.keyCode);
+});
+addEventListener("keyup", function(e) {
+  var index = currentKeys.indexOf(e.keyCode);
+  if (index >= 0) {
+    currentKeys.splice(index, 1);
+  }
+});
+
+exports.withKeys = function (e) {
+  return function(sub) {
+    return e(function(a) {
+      sub({ keys: currentKeys, value: a });
+    });
+  };
+};
+
 exports.down = function(sub) {
   var cb = function(e) {
     sub(e.keyCode);

--- a/src/FRP/Event/Keyboard.js
+++ b/src/FRP/Event/Keyboard.js
@@ -1,13 +1,21 @@
 "use strict";
 
 exports.down = function(sub) {
-  addEventListener("keydown", function(e) {
+  var cb = function(e) {
     sub(e.keyCode);
-  });
+  };
+  addEventListener("keydown", cb);
+  return function() {
+    removeEventListener("keydown", cb);
+  }
 };
 
 exports.up = function(sub) {
-  addEventListener("keyup", function(e) {
+  var cb = function(e) {
     sub(e.keyCode);
-  });
+  };
+  addEventListener("keyup", cb);
+  return function() {
+    removeEventListener("keyup", cb);
+  }
 };

--- a/src/FRP/Event/Keyboard.purs
+++ b/src/FRP/Event/Keyboard.purs
@@ -1,6 +1,7 @@
 module FRP.Event.Keyboard
   ( down
   , up
+  , withKeys
   ) where
 
 import FRP.Event (Event)
@@ -10,3 +11,6 @@ foreign import down :: Event Int
 
 -- | Create an `Event` which fires when a key is released
 foreign import up :: Event Int
+
+-- | Create an event which also returns the current pressed keycodes.
+foreign import withKeys :: forall a. Event a -> Event { value :: a, keys :: Array Int }

--- a/src/FRP/Event/Mouse.js
+++ b/src/FRP/Event/Mouse.js
@@ -1,19 +1,31 @@
 "use strict";
 
 exports.move = function(sub) {
-  addEventListener("mousemove", function(e) {
+  var cb = function(e) {
     sub({ x: e.clientX, y: e.clientY });
-  });
+  };
+  addEventListener("mousemove", cb);
+  return function() {
+    removeEventListener("mousemove", cb);
+  };
 };
 
 exports.down = function(sub) {
-  addEventListener("mousedown", function(e) {
+  var cb = function(e) {
     sub(e.button);
-  });
+  };
+  addEventListener("mousedown", cb);
+  return function() {
+    removeEventListener("mousedown", cb);
+  };
 };
 
 exports.up = function(sub) {
-  addEventListener("mouseup", function(e) {
+  var cb = function(e) {
     sub(e.button);
-  });
+  };
+  addEventListener("mouseup", cb);
+  return function() {
+    removeEventListener("mouseup", cb);
+  };
 };

--- a/src/FRP/Event/Mouse.js
+++ b/src/FRP/Event/Mouse.js
@@ -1,5 +1,37 @@
 "use strict";
 
+var currentPosition;
+addEventListener("mousemove", function(e) {
+  currentPosition = { x: e.clientX, y: e.clientY };
+});
+
+var currentButtons = [];
+addEventListener("mousedown", function(e) {
+  currentButtons.push(e.button);
+});
+addEventListener("mouseup", function(e) {
+  var index = currentButtons.indexOf(e.button);
+  if (index >= 0) {
+    currentButtons.splice(index, 1);
+  }
+});
+
+exports.withPosition = function (e) {
+  return function(sub) {
+    return e(function(a) {
+      sub({ pos: currentPosition, value: a });
+    });
+  };
+};
+
+exports.withButtons = function (e) {
+  return function(sub) {
+    return e(function(a) {
+      sub({ buttons: currentButtons, value: a });
+    });
+  };
+};
+
 exports.move = function(sub) {
   var cb = function(e) {
     sub({ x: e.clientX, y: e.clientY });

--- a/src/FRP/Event/Mouse.purs
+++ b/src/FRP/Event/Mouse.purs
@@ -2,15 +2,24 @@ module FRP.Event.Mouse
   ( move
   , down
   , up
+  , withPosition
+  , withButtons
   ) where
 
+import Data.Nullable (Nullable)
 import FRP.Event (Event)
 
 -- | Create an `Event` which fires when the mouse moves
 foreign import move :: Event { x :: Int, y :: Int }
+
+-- | Create an event which also returns the current mouse position.
+foreign import withPosition :: forall a. Event a -> Event { value :: a, pos :: Nullable { x :: Int, y :: Int } }
 
 -- | Create an `Event` which fires when a mouse button is pressed
 foreign import down :: Event Int
 
 -- | Create an `Event` which fires when a mouse button is released
 foreign import up :: Event Int
+
+-- | Create an event which also returns the current mouse buttons.
+foreign import withButtons :: forall a. Event a -> Event { value :: a, buttons :: Array Int }

--- a/src/FRP/Event/Semantic.purs
+++ b/src/FRP/Event/Semantic.purs
@@ -206,9 +206,15 @@ instance isEventSemantic :: Bounded time => IsEvent (Semantic time) where
   sampleOn (Semantic xs) (Semantic ys) = Semantic (filterMap go ys) where
     go (Tuple t f) = map f <$> latestAt t xs
 
+  keepLatest :: forall a. Semantic time (Semantic time a) -> Semantic time a
+  keepLatest (Semantic es) = Semantic (go es) where
+    go Nil = Nil
+    go (Tuple _ (Semantic xs) : Nil) = xs
+    go (Tuple _ (Semantic xs) : es'@(Tuple tNext _ : _)) = filter ((_ < tNext) <<< fst) xs <> go es'
+
   fix :: forall i o
        . (Semantic time i -> { input :: Semantic time i
                              , output :: Semantic time o
                              })
       -> Semantic time o
-  fix = unsafeCrashWith "FRP.Event.Semantic: fix is not yet implemented"
+  fix _ = unsafeCrashWith "FRP.Event.Semantic: fix is not yet implemented"

--- a/src/FRP/Event/Time.js
+++ b/src/FRP/Event/Time.js
@@ -2,25 +2,34 @@
 
 exports.interval = function (n) {
   return function(sub) {
-    setInterval(function() {
+    var interval = setInterval(function() {
       sub(new Date().getTime());
     }, n);
+    return function() {
+      clearInterval(interval);
+    };
   };
 };
 
 exports.animationFrame = function(sub) {
+  var cancelled = false;
   var loop = function() {
     window.requestAnimationFrame(function() {
       sub();
-      loop();
+      if (!cancelled) {
+        loop();
+      }
     });
   };
   loop();
+  return function() {
+    cancelled = true;
+  }
 };
 
 exports.withTime = function (e) {
   return function(sub) {
-    e(function(a) {
+    return e(function(a) {
       var time = new Date().getTime();
       sub({ time: time, value: a });
     });

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -57,8 +57,12 @@ scene { w, h } = pure background <> map renderCircles circles where
                   | otherwise = 2.0 * (4.0 - s)
     in f <$> buttons <*> b <*> db
 
+  -- This variant resets when the mouse is clicked.
+  swell' :: Behavior Number
+  swell' = switcher swell (down $> swell)
+
   circles :: Behavior (Array Circle)
-  circles = toCircles <$> Mouse.position <*> switcher swell (down $> swell) where
+  circles = toCircles <$> Mouse.position <*> swell' where
     toCircles m sw =
         sortBy (comparing (\{ x, y } -> -(dist x y m))) do
           i <- 0 .. 16

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -11,10 +11,11 @@ import Data.Int (toNumber)
 import Data.Maybe (fromJust, maybe)
 import Data.Set (isEmpty)
 import FRP (FRP)
-import FRP.Behavior (Behavior, animate, solve2')
+import FRP.Behavior (Behavior, animate, solve2', switcher)
 import FRP.Behavior.Mouse (buttons)
 import FRP.Behavior.Mouse as Mouse
 import FRP.Behavior.Time as Time
+import FRP.Event.Mouse (down)
 import Global (infinity)
 import Graphics.Canvas (CANVAS, getCanvasElementById, getCanvasHeight, getCanvasWidth, getContext2D, setCanvasHeight, setCanvasWidth)
 import Graphics.Drawing (Drawing, circle, fillColor, filled, lineWidth, outlineColor, outlined, rectangle, render, scale, translate)
@@ -51,13 +52,13 @@ scene { w, h } = pure background <> map renderCircles circles where
   --
   -- We can solve the differential equation by integration using `solve2'`.
   swell :: Behavior Number
-  swell = solve2' 2.0 0.0 Time.seconds \b db ->
+  swell = solve2' 2.0 15.0 Time.seconds \b db ->
     let f bs s ds | isEmpty bs = -8.0 * (s - 1.0) - ds * 2.0
                   | otherwise = 2.0 * (4.0 - s)
     in f <$> buttons <*> b <*> db
 
   circles :: Behavior (Array Circle)
-  circles = toCircles <$> Mouse.position <*> swell where
+  circles = toCircles <$> Mouse.position <*> switcher swell (down $> swell) where
     toCircles m sw =
         sortBy (comparing (\{ x, y } -> -(dist x y m))) do
           i <- 0 .. 16
@@ -84,4 +85,5 @@ main = do
   h <- getCanvasHeight canvas
   _ <- setCanvasWidth w canvas
   _ <- setCanvasHeight h canvas
-  animate (scene { w, h }) (render ctx)
+  _ <- animate (scene { w, h }) (render ctx)
+  pure unit

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -52,7 +52,7 @@ scene { w, h } = pure background <> map renderCircles circles where
   --
   -- We can solve the differential equation by integration using `solve2'`.
   swell :: Behavior Number
-  swell = solve2' 2.0 15.0 Time.seconds \b db ->
+  swell = solve2' 2.0 5.0 Time.seconds \b db ->
     let f bs s ds | isEmpty bs = -8.0 * (s - 1.0) - ds * 2.0
                   | otherwise = 2.0 * (4.0 - s)
     in f <$> buttons <*> b <*> db


### PR DESCRIPTION
TODO:

- [x] Make key events "hot"
- [x] Move `switcher` and `fixE` into `IsEvent` (or some other classes)
- [x] Documentation and semantics

Notes:

- Events support cancellation now
- It is preferable to have behaviors be "hot" now in the sense that their underlying events are always on. Otherwise `switcher` might cause them to get reconnected, which can cause blips (consider the `move` event which returns `Nothing` until we see the first `mousemove` event).

@i-am-tom @gabejohnson Any thoughts on this API change?