### PR TITLE
Add `Filterable` to the `IsEvent` constraints

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,8 @@
   "dependencies": {
     "purescript-prelude": "^3.0.0",
     "purescript-eff": "^3.0.0",
-    "purescript-sets": "^3.0.0"
+    "purescript-sets": "^3.0.0",
+    "purescript-filterable": "^2.3.0"
   },
   "devDependencies": {
     "purescript-math": "^2.0.0",

--- a/src/FRP/Event.purs
+++ b/src/FRP/Event.purs
@@ -11,11 +11,10 @@ import Prelude
 import Control.Alternative (class Alt, class Alternative, class Plus)
 import Control.Apply (lift2)
 import Control.Monad.Eff (Eff)
-import Data.Filterable (class Filterable)
-import Data.Either (fromLeft, isLeft, fromRight, isRight)
-import Data.Maybe (Maybe, fromJust, isJust)
+import Data.Filterable (class Filterable, filterMap)
+import Data.Either (either, hush)
+import Data.Maybe (Maybe(..), fromJust, isJust)
 import Data.Monoid (class Monoid, mempty)
-import Data.Tuple (Tuple(..), fst, snd)
 import FRP (FRP)
 import FRP.Event.Class as Class
 import Partial.Unsafe (unsafePartial)
@@ -51,9 +50,9 @@ instance filterableEvent :: Filterable Event where
 
   partition p xs = { yes: filter p xs, no: filter (not <<< p) xs }
 
-  partitionMap f xs = let ys = f <$> xs in
-    { left:  unsafePartial (map fromLeft  <<< filter isLeft ) ys
-    , right: unsafePartial (map fromRight <<< filter isRight) ys
+  partitionMap f xs =
+    { left: filterMap (either Just (const Nothing) <<< f) xs
+    , right: filterMap (hush <<< f) xs
     }
 
 instance applyEvent :: Apply Event where

--- a/src/FRP/Event/Class.purs
+++ b/src/FRP/Event/Class.purs
@@ -4,10 +4,10 @@ module FRP.Event.Class
   , folded
   , count
   , mapAccum
-  , module Data.Filterable
   , withLast
   , sampleOn
   , sampleOn_
+  , module Data.Filterable
   ) where
 
 import Prelude

--- a/src/FRP/Event/Time.purs
+++ b/src/FRP/Event/Time.purs
@@ -4,8 +4,10 @@ module FRP.Event.Time
   , withTime
   ) where
 
+import Prelude ((<$>), (-))
+import Data.Tuple (Tuple(..))
 import Data.Unit (Unit)
-import FRP.Event (Event)
+import FRP.Event (Event, sampleOn_)
 
 -- | Create an event which fires every specified number of milliseconds.
 foreign import interval :: Int -> Event Int
@@ -15,3 +17,22 @@ foreign import animationFrame :: Event Unit
 
 -- | Create an event which reports the current time in milliseconds since the epoch.
 foreign import withTime :: forall a. Event a -> Event { value :: a, time :: Int }
+
+-- | Similar to `sampleOn_`, except that the returned `Event` is a `Tuple` of
+-- | the sampled value _as well as_ the time since that value was pushed to the
+-- | stream (in milliseconds).
+withDelay :: forall a b. Event a -> Event b -> Event (Tuple Int a)
+withDelay e sampler = go <$> stream
+  where
+
+    -- The stream with "current" and "first" stamps.
+    stream :: Event { time :: Int
+                    , value :: { time :: Int
+                               , value :: a } }
+    stream = withTime (sampleOn_ (withTime e) sampler)
+
+    -- Calculate a duration!
+    go :: { time :: Int, value :: { time :: Int, value :: a } }
+       -> Tuple Int a
+    go { time: now, value: { time: start, value } } =
+      Tuple (now - start) value


### PR DESCRIPTION
As requested, the PR has been updated. I closed down the others, and I'll sort them out before reopening. Hopefully, this adds a `Filterable` instance to both `Event` and `Semantic`!