### PR TITLE
Use a Set instead of an Array to store key presses.

### DIFF
--- a/src/FRP/Event/Keyboard.js
+++ b/src/FRP/Event/Keyboard.js
@@ -12,7 +12,8 @@ exports.withKeys = function (e) {
   return function(sub) {
     return e(function(a) {
       var currentKeysArray = Object.keys(currentKeys)
-            .filter(function(k) { return currentKeys[k] });
+            .filter(function(k) { return currentKeys[k] })
+            .map(function(k) { return parseInt(k) });
       sub({ keys: currentKeysArray, value: a });
     });
   };

--- a/src/FRP/Event/Keyboard.js
+++ b/src/FRP/Event/Keyboard.js
@@ -1,20 +1,19 @@
 "use strict";
 
-var currentKeys = [];
+var currentKeys = {};
 addEventListener("keydown", function(e) {
-  currentKeys.push(e.keyCode);
+  currentKeys[e.keyCode] = true;
 });
 addEventListener("keyup", function(e) {
-  var index = currentKeys.indexOf(e.keyCode);
-  if (index >= 0) {
-    currentKeys.splice(index, 1);
-  }
+  currentKeys[e.keyCode] = false;
 });
 
 exports.withKeys = function (e) {
   return function(sub) {
     return e(function(a) {
-      sub({ keys: currentKeys, value: a });
+      var currentKeysArray = Object.keys(currentKeys)
+            .filter(function(k) { return currentKeys[k] });
+      sub({ keys: currentKeysArray, value: a });
     });
   };
 };


### PR DESCRIPTION
Key presses were not being removed properly if the key was pressed for more than a second or two, so it behaves as though the keys are pressed down forever. Storing them as a Set is also semantically more correct.

## A simple test case

~~~ purescript
import Prelude
import Control.Monad.Eff.Console (logShow)
import FRP.Event (subscribe)
import FRP.Event.Time (animationFrame)
import FRP.Behavior (sample_)
import FRP.Behavior.Keyboard (keys)

main = do
  _ <- subscribe (sample_ keys animationFrame) logShow
  pure unit
~~~