### PR TITLE
Event with blocking

### DIFF
--- a/src/FRP/Event/Class.purs
+++ b/src/FRP/Event/Class.purs
@@ -16,7 +16,7 @@ module FRP.Event.Class
 
 import Prelude
 
-import Control.Alternative (class Alternative)
+import Control.Alternative (class Alternative, (<|>))
 import Data.Filterable (class Filterable, filterMap, filtered)
 import Data.Maybe (Maybe(..))
 import Data.Monoid (class Monoid, mempty)
@@ -70,20 +70,24 @@ mapAccum f xs acc = filterMap snd
 sampleOn_ :: forall event a b. IsEvent event => event a -> event b -> event a
 sampleOn_ a b = sampleOn a (b $> id)
 
--- | Sample the events that are fired while a boolean event is true.
+-- | Sample the events that are fired while a boolean event is true. Note that,
+-- | until the boolean event fires, it will be assumed to be `false`, and events
+-- | will be blocked.
 gate :: forall a event. IsEvent event => event Boolean -> event a -> event a
-gate = gateBy const
+gate = gateBy const false
 
--- | Generalised form of `gateBy`, allowing for any predicate between
--- | the two events. When true, the second event is sampled.
+-- | Generalised form of `gateBy`, allowing for any predicate between the two
+-- | events. An initial value for the event is also required, and will be used
+-- | until the second event fires an event.
 gateBy
-  :: forall a b event.
-     IsEvent event
+  :: forall a b event
+   . IsEvent event
   => (a -> b -> Boolean)
+  -> a
   -> event a
   -> event b
   -> event b
-gateBy f s
+gateBy f init sampled
    = filtered
- <<< sampleOn s
+ <<< sampleOn (pure init <|> sampled)
  <<< map \x p -> if f p x then Just x else Nothing

--- a/src/FRP/Event/Class.purs
+++ b/src/FRP/Event/Class.purs
@@ -9,13 +9,15 @@ module FRP.Event.Class
   , sampleOn_
   , keepLatest
   , fix
+  , gate
+  , gateBy
   , module Data.Filterable
   ) where
 
 import Prelude
 
 import Control.Alternative (class Alternative)
-import Data.Filterable (class Filterable, filterMap)
+import Data.Filterable (class Filterable, filterMap, filtered)
 import Data.Maybe (Maybe(..))
 import Data.Monoid (class Monoid, mempty)
 import Data.Tuple (Tuple(..), snd)
@@ -67,3 +69,21 @@ mapAccum f xs acc = filterMap snd
 -- | the second event.
 sampleOn_ :: forall event a b. IsEvent event => event a -> event b -> event a
 sampleOn_ a b = sampleOn a (b $> id)
+
+-- | Sample the events that are fired while a boolean event is true.
+gate :: forall a event. IsEvent event => event Boolean -> event a -> event a
+gate = gateBy const
+
+-- | Generalised form of `gateBy`, allowing for any predicate between
+-- | the two events. When true, the second event is sampled.
+gateBy
+  :: forall a b event.
+     IsEvent event
+  => (a -> b -> Boolean)
+  -> event a
+  -> event b
+  -> event b
+gateBy f s
+   = filtered
+ <<< sampleOn s
+ <<< map \x p -> if f p x then Just x else Nothing

--- a/src/FRP/Event/Time.purs
+++ b/src/FRP/Event/Time.purs
@@ -4,8 +4,12 @@ module FRP.Event.Time
   , withTime
   ) where
 
+import Prelude ((<<<), const, map)
+import Data.Filterable (filtered)
+import Data.Maybe (Maybe(..))
 import Data.Unit (Unit)
 import FRP.Event (Event)
+import FRP.Event.Class (sampleOn)
 
 -- | Create an event which fires every specified number of milliseconds.
 foreign import interval :: Int -> Event Int
@@ -15,3 +19,20 @@ foreign import animationFrame :: Event Unit
 
 -- | Create an event which reports the current time in milliseconds since the epoch.
 foreign import withTime :: forall a. Event a -> Event { value :: a, time :: Number }
+
+-- | Sample the events that are fired while a boolean event is true.
+gate :: forall a. Event Boolean -> Event a -> Event a
+gate = gateBy const
+
+-- | Generalised form of `gateBy`, allowing for any predicate between
+-- | the two events. When true, the second event is sampled.
+gateBy
+  :: forall a b.
+     (a -> b -> Boolean)
+  -> Event a
+  -> Event b
+  -> Event b
+gateBy f s
+   = filtered
+ <<< sampleOn s
+ <<< map \x p -> if f p x then Just x else Nothing

--- a/src/FRP/Event/Time.purs
+++ b/src/FRP/Event/Time.purs
@@ -4,12 +4,8 @@ module FRP.Event.Time
   , withTime
   ) where
 
-import Prelude ((<<<), const, map)
-import Data.Filterable (filtered)
-import Data.Maybe (Maybe(..))
 import Data.Unit (Unit)
 import FRP.Event (Event)
-import FRP.Event.Class (sampleOn)
 
 -- | Create an event which fires every specified number of milliseconds.
 foreign import interval :: Int -> Event Int
@@ -19,20 +15,3 @@ foreign import animationFrame :: Event Unit
 
 -- | Create an event which reports the current time in milliseconds since the epoch.
 foreign import withTime :: forall a. Event a -> Event { value :: a, time :: Number }
-
--- | Sample the events that are fired while a boolean event is true.
-gate :: forall a. Event Boolean -> Event a -> Event a
-gate = gateBy const
-
--- | Generalised form of `gateBy`, allowing for any predicate between
--- | the two events. When true, the second event is sampled.
-gateBy
-  :: forall a b.
-     (a -> b -> Boolean)
-  -> Event a
-  -> Event b
-  -> Event b
-gateBy f s
-   = filtered
- <<< sampleOn s
- <<< map \x p -> if f p x then Just x else Nothing

--- a/src/FRP/Event/Time.purs
+++ b/src/FRP/Event/Time.purs
@@ -4,8 +4,10 @@ module FRP.Event.Time
   , withTime
   ) where
 
-import Data.Unit (Unit)
+import Prelude ((<), (+), map, pure, Unit)
+import Control.Alt ((<|>))
 import FRP.Event (Event)
+import FRP.Event.Class (fix, gateBy)
 
 -- | Create an event which fires every specified number of milliseconds.
 foreign import interval :: Int -> Event Int
@@ -15,3 +17,38 @@ foreign import animationFrame :: Event Unit
 
 -- | Create an event which reports the current time in milliseconds since the epoch.
 foreign import withTime :: forall a. Event a -> Event { value :: a, time :: Number }
+
+-- | Provided an input event and transformation, block the input event for the
+-- | duration of the specified period on each output.
+withBlocking
+  :: forall a b.
+     (Event a -> Event { period :: Number, value :: b })
+  -> Event a
+  -> Event b
+withBlocking process event
+  = fix \allowed ->
+      let
+        processed :: Event { period :: Number, value :: b }
+        processed = process allowed
+
+        expiries :: Event Number
+        expiries = pure 0.0 <|>
+          map (\{ time, value } -> time + value)
+              (withTime (map _.period processed))
+
+        comparison :: forall r. Number -> { time :: Number | r } -> Boolean
+        comparison a b = a < b.time
+
+        unblocked :: Event { time :: Number, value :: a }
+        unblocked = gateBy comparison expiries stamped
+      in
+        { input:  map _.value unblocked
+        , output: map _.value processed
+        }
+  where
+    stamped :: Event { time :: Number, value :: a }
+    stamped = withTime event
+
+-- | On each event, ignore subsequent events for a given number of milliseconds.
+debounce :: forall a. Number -> Event a -> Event a
+debounce period = withBlocking (map \value -> { period, value })

--- a/src/FRP/Event/Time.purs
+++ b/src/FRP/Event/Time.purs
@@ -40,7 +40,7 @@ withBlocking process event
         comparison a b = a < b.time
 
         unblocked :: Event { time :: Number, value :: a }
-        unblocked = gateBy comparison expiries stamped
+        unblocked = gateBy comparison 0.0 expiries stamped
       in
         { input:  map _.value unblocked
         , output: map _.value processed


### PR DESCRIPTION
The `withBlocking` function uses `fix` to allow us to block inputs based on values discovered later in the process. A lot of the insight here comes from @monoidmusician, to whom I'm eternally grateful.