### PR TITLE
Ensure no duplicate keys

### DIFF
--- a/src/FRP/Event/Keyboard.js
+++ b/src/FRP/Event/Keyboard.js
@@ -2,7 +2,10 @@
 
 var currentKeys = [];
 addEventListener("keydown", function(e) {
-  currentKeys.push(e.keyCode);
+  var index = currentKeys.indexOf(e.keyCode);
+  if (index < 0) {
+    currentKeys.push(e.keyCode);
+  }
 });
 addEventListener("keyup", function(e) {
   var index = currentKeys.indexOf(e.keyCode);


### PR DESCRIPTION
When a key is held down such that the OS sends repeats, "keydown" will be called before "keyup", so we need to ensure that the key is not present in the array before inserting it.