### PR TITLE
Export `debounce` and `debounceWith`

### DIFF
--- a/src/FRP/Event/Time.purs
+++ b/src/FRP/Event/Time.purs
@@ -2,6 +2,8 @@ module FRP.Event.Time
   ( interval
   , animationFrame
   , withTime
+  , debounce
+  , debounceWith
   ) where
 
 import Data.Maybe (Maybe, maybe)


### PR DESCRIPTION
I did a silly :(

This is, however, supplying plenty of motivation to that compiler PR to warn on unused+unexported top-level declarations. I'll try to get it done this week. Sorry for this, Phil!