### PR TITLE
Update `mapAccum` docs (and implementation!)

### DIFF
--- a/src/FRP/Event/Class.purs
+++ b/src/FRP/Event/Class.purs
@@ -57,10 +57,10 @@ withLast e = filterMap id (fold step e Nothing) where
 -- | For example, to keep the index of the current event:
 -- |
 -- | ```purescript
--- | mapAccum (\x i -> Tuple (i + 1) (Tuple x i)) 0`.
+-- | mapAccum (\x i -> Tuple (i + 1) (Tuple x i)) 0
 -- | ```
-mapAccum :: forall event a b c. IsEvent event => (a -> b -> Tuple b c) -> event a -> b -> event c
-mapAccum f xs acc = filterMap snd
+mapAccum :: forall event a b c. IsEvent event => (a -> b -> Tuple b c) -> b -> event a -> event c
+mapAccum f acc xs = filterMap snd
   $ fold (\a (Tuple b _) -> pure <$> f a b) xs
   $ Tuple acc Nothing
 


### PR DESCRIPTION
Previously, the `mapAccum` arguments were not in the order one might expect (i.e. the same as other fold-style functions: `function accumulator foldable`). This has been corrected. Furthermore, the documentation contained a formatting error, which has been fixed.